### PR TITLE
Zeta data path end-to-end integration with Alcor ACA/OVS

### DIFF
--- a/src/cli/test/test_cli.c
+++ b/src/cli/test/test_cli.c
@@ -506,12 +506,12 @@ static void test_trn_cli_update_ep_subcmd(void **state)
 				]
 			  	}) };
 
-	char mac[6] = { 0x60, 0x50, 0x40, 0x30, 0x20, 0x10 };
-	char hmac[6] = { 0x10, 0x20, 0x30, 0x40, 0x50, 0x60 };
+	char hmac[6] = { 0x60, 0x50, 0x40, 0x30, 0x20, 0x10 };
+	char mac[6] = { 0x10, 0x20, 0x30, 0x40, 0x50, 0x60 };
 	trn_ep_t ep = {
 		.xdp_ep.key.vni = 3,
-		.xdp_ep.key.ip = 0x908E926C,
-		.xdp_ep.val.hip = 0x908E926D,
+		.xdp_ep.key.ip = 0x6c928E90,
+		.xdp_ep.val.hip = 0x6D928E90,
 	};
 	memcpy(ep.xdp_ep.val.mac, mac, sizeof(mac));
 	memcpy(ep.xdp_ep.val.hmac, hmac, sizeof(hmac));

--- a/src/cli/trn_cli.h
+++ b/src/cli/trn_cli.h
@@ -31,6 +31,7 @@
 #include <stdint.h>
 #include <arpa/inet.h>
 #include <errno.h>
+#include <endian.h>
 #include "extern/cJSON.h"
 #include "extern/ketopt.h"
 
@@ -57,13 +58,16 @@ int trn_cli_read_conf_str(ketopt_t *om, int argc, char *argv[],
 
 cJSON *trn_cli_parse_json(const char *buf);
 int trn_cli_parse_json_string(const cJSON *jsonobj, const char *const key, char *buf);
-int trn_cli_parse_json_number_ip(const cJSON *jsonobj, const char *const key,
+int trn_cli_parse_json_number_u16n(const cJSON *jsonobj, const char *const key,
+	unsigned short *buf);
+int trn_cli_parse_json_number_u32n(const cJSON *jsonobj, const char *const key,
 	unsigned int *buf);
 int trn_cli_parse_json_number_mac(const cJSON *jsonobj, const char *const key,
 	unsigned char *buf);
-int trn_cli_parse_json_number(const cJSON *jsonobj, const char *const key, int *buf);
-int trn_cli_parse_json_ip(const cJSON *jsonobj, const char *const key, unsigned int *buf);
-int trn_cli_parse_json_mac(const cJSON *jsonobj, const char *const key, unsigned char *buf);
+int trn_cli_parse_json_number_u32(const cJSON *jsonobj, const char *const key,
+	unsigned int *buf);
+int trn_cli_parse_json_str_ip(const cJSON *jsonobj, const char *const key, unsigned int *buf);
+int trn_cli_parse_json_str_mac(const cJSON *jsonobj, const char *const key, unsigned char *buf);
 int trn_cli_parse_zeta_key(const cJSON *jsonobj,
 			   struct rpc_trn_zeta_key_t *zeta_key);
 

--- a/src/cli/trn_cli_common.c
+++ b/src/cli/trn_cli_common.c
@@ -53,7 +53,28 @@ int trn_cli_parse_json_string(const cJSON *jsonobj, const char *const key, char 
 	return 0;
 }
 
-int trn_cli_parse_json_number_ip(const cJSON *jsonobj, const char *const key,
+int trn_cli_parse_json_number_u16n(const cJSON *jsonobj, const char *const key,
+	unsigned short *buf)
+{
+	cJSON *item = cJSON_GetObjectItem(jsonobj, key);
+
+	if (item == NULL) {
+		print_err("Missing %s\n", key);
+		return -EINVAL;
+	} else if (!cJSON_IsNumber(item)) {
+		print_err("Invalid %s type, should be number\n", key);
+		return -EINVAL;
+	}
+	unsigned short tmp = (unsigned short)item->valuedouble;
+	*buf = 0;
+	for (unsigned int i = 0; i < sizeof(unsigned short); i++) {
+		*buf = (*buf << 8) | (tmp & 0xFF);
+		tmp >>= 8;
+	}
+	return 0;
+}
+
+int trn_cli_parse_json_number_u32n(const cJSON *jsonobj, const char *const key,
 	unsigned int *buf)
 {
 	cJSON *item = cJSON_GetObjectItem(jsonobj, key);
@@ -65,7 +86,12 @@ int trn_cli_parse_json_number_ip(const cJSON *jsonobj, const char *const key,
 		print_err("Invalid %s type, should be number\n", key);
 		return -EINVAL;
 	}
-	*buf = (unsigned int)item->valuedouble;
+	unsigned int tmp = (unsigned int)item->valuedouble;
+	*buf = 0;
+	for (unsigned int i = 0; i < sizeof(unsigned int); i++) {
+		*buf = (*buf << 8) | (tmp & 0xFF);
+		tmp >>= 8;
+	}
 	return 0;
 }
 
@@ -83,13 +109,14 @@ int trn_cli_parse_json_number_mac(const cJSON *jsonobj, const char *const key,
 	}
 	uint64_t vd = ((uint64_t)item->valuedouble & 0xFFFFFFFFFFFF);
 	for (int i = 0; i < 6; i++) {
-		buf[i] = (unsigned char)vd;
+		buf[5 - i] = (unsigned char)vd;
 		vd >>= 8;
 	}
 	return 0;
 }
 
-int trn_cli_parse_json_number(const cJSON *jsonobj, const char *const key, int *buf)
+int trn_cli_parse_json_number_u32(const cJSON *jsonobj, const char *const key,
+	unsigned int *buf)
 {
 	cJSON *item = cJSON_GetObjectItem(jsonobj, key);
 
@@ -100,11 +127,11 @@ int trn_cli_parse_json_number(const cJSON *jsonobj, const char *const key, int *
 		print_err("Invalid %s type, should be number\n", key);
 		return -EINVAL;
 	}
-	*buf = (int)item->valuedouble;
+	*buf = (unsigned int)item->valuedouble;
 	return 0;
 }
 
-int trn_cli_parse_json_ip(const cJSON *jsonobj, const char *const key, unsigned int *buf)
+int trn_cli_parse_json_str_ip(const cJSON *jsonobj, const char *const key, unsigned int *buf)
 {
 	cJSON *item = cJSON_GetObjectItem(jsonobj, key);
 
@@ -121,7 +148,7 @@ int trn_cli_parse_json_ip(const cJSON *jsonobj, const char *const key, unsigned 
 	return 0;
 }
 
-int trn_cli_parse_json_mac(const cJSON *jsonobj, const char *const key, unsigned char *buf)
+int trn_cli_parse_json_str_mac(const cJSON *jsonobj, const char *const key, unsigned char *buf)
 {
 	cJSON *item = cJSON_GetObjectItem(jsonobj, key);
 

--- a/src/cli/trn_cli_droplet.c
+++ b/src/cli/trn_cli_droplet.c
@@ -19,7 +19,7 @@ int trn_cli_parse_droplet(const cJSON *jsonobj, struct rpc_trn_droplet_t *drople
 		return -EINVAL;
 	}
 
-	if (trn_cli_parse_json_number(jsonobj, "num_entrances", (int *)&droplet->num_entrances)) {
+	if (trn_cli_parse_json_number_u32(jsonobj, "num_entrances", &droplet->num_entrances)) {
 		return -EINVAL;
 	} else if ( droplet->num_entrances > TRAN_MAX_ZGC_ENTRANCES) {
 		print_err("Error: num_entrances over limit %d\n", TRAN_MAX_ZGC_ENTRANCES);
@@ -40,11 +40,11 @@ int trn_cli_parse_droplet(const cJSON *jsonobj, struct rpc_trn_droplet_t *drople
 	int i = 0;
 	cJSON *entrance;
 	cJSON_ArrayForEach(entrance, entrances)	{
-		if (trn_cli_parse_json_ip(entrance, "ip", &droplet->entrances[i].ip)) {
+		if (trn_cli_parse_json_str_ip(entrance, "ip", &droplet->entrances[i].ip)) {
 			return -EINVAL;
 		}
 
-		if (trn_cli_parse_json_mac(entrance, "mac", &droplet->entrances[i].mac[0])) {
+		if (trn_cli_parse_json_str_mac(entrance, "mac", &droplet->entrances[i].mac[0])) {
 			return -EINVAL;
 		}
 		i++;

--- a/src/cli/trn_cli_ep.c
+++ b/src/cli/trn_cli_ep.c
@@ -28,11 +28,11 @@ int trn_cli_parse_ep_key(const cJSON *jsonobj,
 			 rpc_endpoint_key_t *epk)
 {
 
-	if (trn_cli_parse_json_number(jsonobj, "vni", (int *)&epk->vni)) {
+	if (trn_cli_parse_json_number_u32(jsonobj, "vni", &epk->vni)) {
 		return -EINVAL;
 	}
 
-	if (trn_cli_parse_json_ip(jsonobj, "ip", &epk->ip)) {
+	if (trn_cli_parse_json_str_ip(jsonobj, "ip", &epk->ip)) {
 		return -EINVAL;
 	}
 
@@ -43,8 +43,8 @@ int trn_cli_parse_ep(const cJSON *jsonobj, rpc_trn_endpoint_batch_t *batch)
 {
 	cJSON *eps = cJSON_GetObjectItem(jsonobj, "eps");
 
-	if (trn_cli_parse_json_number(jsonobj, "size",
-		(int *)&batch->rpc_trn_endpoint_batch_t_len)) {
+	if (trn_cli_parse_json_number_u32(jsonobj, "size",
+		&batch->rpc_trn_endpoint_batch_t_len)) {
 		return -EINVAL;
 	} else if (batch->rpc_trn_endpoint_batch_t_len > TRAN_MAX_EP_BATCH_SIZE) {
 		print_err("Number of elements in batch over limit %d\n",
@@ -74,15 +74,15 @@ int trn_cli_parse_ep(const cJSON *jsonobj, rpc_trn_endpoint_batch_t *batch)
 	trn_ep_t *item = items;
 	cJSON *ep;
 	cJSON_ArrayForEach(ep, eps) {
-		if (trn_cli_parse_json_number(ep, "vni", (int *)&item->xdp_ep.key.vni)) {
+		if (trn_cli_parse_json_number_u32(ep, "vni", &item->xdp_ep.key.vni)) {
 			goto cleanup;
 		}
 
-		if (trn_cli_parse_json_number_ip(ep, "ip", &item->xdp_ep.key.ip)) {
+		if (trn_cli_parse_json_number_u32n(ep, "ip", &item->xdp_ep.key.ip)) {
 			goto cleanup;
 		}
 
-		if (trn_cli_parse_json_number_ip(ep, "hip", &item->xdp_ep.val.hip)) {
+		if (trn_cli_parse_json_number_u32n(ep, "hip", &item->xdp_ep.val.hip)) {
 			goto cleanup;
 		}
 

--- a/src/cli/trn_cli_xdp.c
+++ b/src/cli/trn_cli_xdp.c
@@ -49,8 +49,8 @@ int trn_cli_parse_ebpf_prog(const cJSON *jsonobj, rpc_trn_ebpf_prog_t *prog)
 		}
 	}
 
-	if (trn_cli_parse_json_number(jsonobj,
-		"debug_mode", (int *)&prog->debug_mode)) {
+	if (trn_cli_parse_json_number_u32(jsonobj,
+		"debug_mode", &prog->debug_mode)) {
 		return -EINVAL;
 	}
 
@@ -71,12 +71,9 @@ int trn_cli_parse_xdp(const cJSON *jsonobj, rpc_trn_xdp_intf_t *xdp_intf)
 		return -EINVAL;
 	}
 
-	if (trn_cli_parse_json_number(jsonobj, "ibo_port", &tmp)) {
+	if (trn_cli_parse_json_number_u16n(jsonobj,
+		"ibo_port", &xdp_intf->ibo_port)) {
 		return -EINVAL;
-	} else if (tmp & 0xFFFF0000) {
-		return -EINVAL;
-	} else {
-		xdp_intf->ibo_port = (uint16_t)tmp;
 	}
 
 	cJSON *debug_mode = cJSON_GetObjectItem(jsonobj, "debug_mode");
@@ -84,8 +81,8 @@ int trn_cli_parse_xdp(const cJSON *jsonobj, rpc_trn_xdp_intf_t *xdp_intf)
 		/* Make debug_mode optional */
 		xdp_intf->debug_mode = 1;
 	} else {
-		if (trn_cli_parse_json_number(jsonobj,
-			"debug_mode", (int *)&xdp_intf->debug_mode)) {
+		if (trn_cli_parse_json_number_u32(jsonobj,
+			"debug_mode", &xdp_intf->debug_mode)) {
 			return -EINVAL;
 		}
 	}

--- a/src/dmn/trn_transit_xdp_usr.c
+++ b/src/dmn/trn_transit_xdp_usr.c
@@ -933,8 +933,8 @@ int trn_transit_dp_assistant(void)
 	oam_fd = trn_transit_map_get_fd("oam_queue_map");
 
 	/* Open RAW socket to send on */
-	if ((sockfd = socket(AF_PACKET, SOCK_RAW, IPPROTO_RAW)) == -1) {
-	    TRN_LOG_ERROR("DPA failed to open raw socket!");
+	if ((sockfd = socket(AF_PACKET, SOCK_RAW, IPPROTO_RAW)) < 0) {
+	    TRN_LOG_ERROR("DPA failed to open raw socket! Err: %s", strerror(errno));
 		return 1;
 	}
 
@@ -953,8 +953,8 @@ int trn_transit_dp_assistant(void)
 				sizeof(sendbuf.eth.h_dest));
 			if (sendto(sockfd, &sendbuf.eth, sendbuf.len, 0,
 				(struct sockaddr*)&socket_address, sizeof(struct sockaddr_ll)) < 0) {
-				TRN_LOG_ERROR("DPA failed to send oam packet to 0x%08x.",
-					sendbuf.ip.daddr);
+				TRN_LOG_ERROR("DPA failed to send oam packet to 0x%08x, err: %s",
+					sendbuf.ip.daddr, strerror(errno));
 			}
 		}
 	}

--- a/src/mgmt/manager/project/api/nodes.py
+++ b/src/mgmt/manager/project/api/nodes.py
@@ -18,14 +18,13 @@ from flask import (
 )
 from kubernetes.client.rest import ApiException
 from kubernetes import client, config
-from project.api.models import Node
-from project.api.models import Zgc
+from project.api.models import Node, Zgc
+from project import db
 from project.api.utils import getGWsFromIpRange, get_mac_from_ip
 from project.api.settings import activeZgc, zgc_cidr_range, node_ips
 from common.rpc import TrnRpc
 
-logger = logging.getLogger('gunicorn.error')
-
+logger = logging.getLogger()
 config.load_incluster_config()
 obj_api = client.CustomObjectsApi()
 nodes_blueprint = Blueprint('nodes', __name__)

--- a/src/mgmt/manager/project/api/ports.py
+++ b/src/mgmt/manager/project/api/ports.py
@@ -19,6 +19,7 @@ from flask import (
 from project.api.models import Port, Host, EP
 from project.api.settings import node_ips, vnis
 from project.api.utils import ip_to_int, mac_to_int
+from project import db
 from common.rpc import TrnRpc
 
 # Make sure matching TRAN_MAX_EP_BATCH_SIZE in trn_datamodel.h

--- a/src/mgmt/manager/project/api/vpcs.py
+++ b/src/mgmt/manager/project/api/vpcs.py
@@ -20,7 +20,7 @@ from project.api.utils import getGWsFromIpRange
 import time
 import logging
 
-logger = logging.getLogger('gunicorn.error')
+logger = logging.getLogger()
 
 vpcs_blueprint = Blueprint('vpcs', __name__)
 

--- a/src/mgmt/manager/project/api/zgcs.py
+++ b/src/mgmt/manager/project/api/zgcs.py
@@ -19,7 +19,7 @@ from project import db
 import time
 import logging
 
-logger = logging.getLogger('gunicorn.error')
+logger = logging.getLogger()
 zgcs_blueprint = Blueprint('zgcs', __name__)
 
 


### PR DESCRIPTION
Complete round trip test passed:
1. Zeta ZGC nodes act as ARP responder for tenant ARP request (inner) - ARP over VxLAN: pass
2.Zeta ZGC nodes receives the initial tenant flow packet (ICMP ping in test), lookup target MAC and host IP/MAC, re-encap the packet and forward it to host hosting target tenant instance - IP over VxLAN rewrite and forwarding: pass
3. For forwarded flow in 2 above, ZGC nodes send Direct-Path rule injection OAM packet to flow initiator - OAM in-band control: pass
4. For reverse flow (Ping respond in test case), ZGC nodes handling is same as 2 and 3 above: Pass

Detailed integration process is documented [here](https://github.com/futurewei-cloud/alcor-control-agent/issues/189)
 
Pseudo controller test result:
```
Time for the Ping test
port response in json_content_for_aca:
[[{'ip_node': '192.168.20.93', 'ips_port': [{'ip': '123.0.0.1', 'vip': ''}], 'mac_node': 'e8:bd:d1:01:72:c8', 'mac_port': '6c:dd:ee:0:0:1', 'port_id': '0000001ae-7dec-11d0-a765-00a0c9341120', 'vpc_id': '3dda2801-d675-4688-a63f-dcda8d327f61'}, {'ip_node': '192.168.20.92', 'ips_port': [{'ip': '123.0.0.2', 'vip': ''}], 'mac_node': 'e8:bd:d1:01:77:ec', 'mac_port': '6c:dd:ee:0:0:2', 'port_id': '0000002ae-7dec-11d0-a765-00a0c9341120', 'vpc_id': '3dda2801-d675-4688-a63f-dcda8d327f61'}]]
Dump flow before PING:
executing command: sudo ovs-ofctl dump-flows br-tun
Output: Huawei@2018
[sudo] password for user:
 cookie=0x0, duration=0.559s, table=0, n_packets=2, n_bytes=141, priority=1,in_port="patch-int" actions=resubmit(,2)
 cookie=0x0, duration=0.516s, table=0, n_packets=0, n_bytes=0, priority=25,in_port="vxlan-generic" actions=resubmit(,4)
 cookie=0x0, duration=0.574s, table=0, n_packets=0, n_bytes=0, priority=0 actions=NORMAL
 cookie=0x0, duration=0.540s, table=2, n_packets=0, n_bytes=0, priority=25,arp,in_port="patch-int",arp_op=1 actions=resubmit(,51)
 cookie=0x0, duration=0.532s, table=2, n_packets=0, n_bytes=0, priority=25,icmp,in_port="patch-int",icmp_type=8 actions=resubmit(,52)
 cookie=0x0, duration=0.554s, table=2, n_packets=0, n_bytes=0, priority=1,dl_dst=00:00:00:00:00:00/01:00:00:00:00:00 actions=resubmit(,20)
 cookie=0x0, duration=0.549s, table=2, n_packets=2, n_bytes=141, priority=1,dl_dst=01:00:00:00:00:00/01:00:00:00:00:00 actions=resubmit(,22)
 cookie=0x0, duration=0.489s, table=4, n_packets=0, n_bytes=0, priority=1,tun_id=0x378 actions=mod_vlan_vid:1,output:"patch-int"
 cookie=0x0, duration=0.544s, table=20, n_packets=0, n_bytes=0, priority=1 actions=resubmit(,22)
 cookie=0x0, duration=0.453s, table=22, n_packets=1, n_bytes=87, priority=50,dl_vlan=1 actions=strip_vlan,load:0x378->NXM_NX_TUN_ID[],group:1
 cookie=0x0, duration=0.536s, table=51, n_packets=0, n_bytes=0, priority=1 actions=resubmit(,22)
 cookie=0x0, duration=0.528s, table=52, n_packets=0, n_bytes=0, priority=1 actions=resubmit(,20)

Command for ping: ping -I 123.0.0.2 -c1 123.0.0.1
executing command: ping -I 123.0.0.2 -c1 123.0.0.1
Output: PING 123.0.0.1 (123.0.0.1) from 123.0.0.2 : 56(84) bytes of data.
64 bytes from 123.0.0.1: icmp_seq=1 ttl=64 time=2.33 ms

--- 123.0.0.1 ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 2.337/2.337/2.337/0.000 ms

Dump flow after PING:
executing command: sudo ovs-ofctl dump-flows br-tun
Output: Huawei@2018
[sudo] password for user:
 cookie=0x0, duration=1.256s, table=0, n_packets=10, n_bytes=938, priority=1,in_port="patch-int" actions=resubmit(,2)
 cookie=0x0, duration=1.213s, table=0, n_packets=2, n_bytes=140, priority=25,in_port="vxlan-generic" actions=resubmit(,4)
 cookie=0x0, duration=1.271s, table=0, n_packets=0, n_bytes=0, priority=0 actions=NORMAL
 cookie=0x0, duration=1.237s, table=2, n_packets=1, n_bytes=42, priority=25,arp,in_port="patch-int",arp_op=1 actions=resubmit(,51)
 cookie=0x0, duration=1.229s, table=2, n_packets=1, n_bytes=98, priority=25,icmp,in_port="patch-int",icmp_type=8 actions=resubmit(,52)
 cookie=0x0, duration=1.251s, table=2, n_packets=0, n_bytes=0, priority=1,dl_dst=00:00:00:00:00:00/01:00:00:00:00:00 actions=resubmit(,20)
 cookie=0x0, duration=1.246s, table=2, n_packets=8, n_bytes=798, priority=1,dl_dst=01:00:00:00:00:00/01:00:00:00:00:00 actions=resubmit(,22)
 cookie=0x0, duration=1.186s, table=4, n_packets=2, n_bytes=140, priority=1,tun_id=0x378 actions=mod_vlan_vid:1,output:"patch-int"
 cookie=0x0, duration=1.241s, table=20, n_packets=1, n_bytes=98, priority=1 actions=resubmit(,22)
 cookie=0x0, duration=1.150s, table=22, n_packets=9, n_bytes=884, priority=50,dl_vlan=1 actions=strip_vlan,load:0x378->NXM_NX_TUN_ID[],group:1
 cookie=0x0, duration=1.233s, table=51, n_packets=1, n_bytes=42, priority=1 actions=resubmit(,22)
 cookie=0x0, duration=1.225s, table=52, n_packets=1, n_bytes=98, priority=1 actions=resubmit(,20)

Ping succeeded: True
This is the end of the pseudo controller, goodbye.
```

Packet dump on ping requester (ACA parent) showing ARP request/respond (pcap 1,2), Ping Request/respond(pcap 3,6) and OAM for direct-path OVS rule injection (pcap 4):
```
23:46:50.931939 e8:bd:d1:01:77:ec > 82:83:c0:a8:14:6c, ethertype IPv4 (0x0800), length 92: 192.168.20.92.42216 > 192.168.20.108.4789: VXLAN, flags [I] (0x08), vni 888
6c:dd:ee:00:00:02 > ff:ff:ff:ff:ff:ff, ethertype ARP (0x0806), length 42: Request who-has 123.0.0.1 tell 123.0.0.2, length 28
	0x0000:  8283 c0a8 146c e8bd d101 77ec 0800 4500  .....l....w...E.
	0x0010:  004e cb0c 4000 4011 c579 c0a8 145c c0a8  .N..@.@..y...\..
	0x0020:  146c a4e8 12b5 003a 0000 0800 0000 0003  .l.....:........
	0x0030:  7800 ffff ffff ffff 6cdd ee00 0002 0806  x.......l.......
	0x0040:  0001 0800 0604 0001 6cdd ee00 0002 7b00  ........l.....{.
	0x0050:  0002 0000 0000 0000 7b00 0001            ........{...
23:46:50.932171 82:83:c0:a8:14:6c > e8:bd:d1:01:77:ec, ethertype IPv4 (0x0800), length 92: 192.168.20.108.42216 > 192.168.20.92.4789: VXLAN, flags [I] (0x08), vni 888
6c:dd:ee:00:00:01 > 6c:dd:ee:00:00:02, ethertype ARP (0x0806), length 42: Reply 123.0.0.1 is-at 6c:dd:ee:00:00:01, length 28
	0x0000:  e8bd d101 77ec 8283 c0a8 146c 0800 4500  ....w......l..E.
	0x0010:  004e cb0c 4000 3f11 c679 c0a8 146c c0a8  .N..@.?..y...l..
	0x0020:  145c a4e8 12b5 003a 0000 0800 0000 0003  .\.....:........
	0x0030:  7800 6cdd ee00 0002 6cdd ee00 0001 0806  x.l.....l.......
	0x0040:  0001 0800 0604 0002 6cdd ee00 0001 7b00  ........l.....{.
	0x0050:  0001 6cdd ee00 0002 7b00 0002            ..l.....{...
23:46:50.932551 e8:bd:d1:01:77:ec > 82:83:c0:a8:14:6e, ethertype IPv4 (0x0800), length 148: 192.168.20.92.36828 > 192.168.20.110.4789: VXLAN, flags [I] (0x08), vni 888
6c:dd:ee:00:00:02 > 6c:dd:ee:00:00:01, ethertype IPv4 (0x0800), length 98: 123.0.0.2 > 123.0.0.1: ICMP echo request, id 23422, seq 1, length 64
	0x0000:  8283 c0a8 146e e8bd d101 77ec 0800 4500  .....n....w...E.
	0x0010:  0086 0683 4000 4011 89c9 c0a8 145c c0a8  ....@.@......\..
	0x0020:  146e 8fdc 12b5 0072 0000 0800 0000 0003  .n.....r........
	0x0030:  7800 6cdd ee00 0001 6cdd ee00 0002 0800  x.l.....l.......
	0x0040:  4500 0054 8729 4000 4001 bd7c 7b00 0002  E..T.)@.@..|{...
	0x0050:  7b00 0001 0800 a81f 5b7e 0001 eaf6 ff5f  {.......[~....._
	0x0060:  0000 0000 3d37 0e00 0000 0000 1011 1213  ....=7..........
	0x0070:  1415 1617 1819 1a1b 1c1d 1e1f 2021 2223  .............!"#
	0x0080:  2425 2627 2829 2a2b 2c2d 2e2f 3031 3233  $%&'()*+,-./0123
	0x0090:  3435 3637                                4567
23:46:50.932999 82:83:c0:a8:14:6e > e8:bd:d1:01:77:ec, ethertype IPv4 (0x0800), length 86: 192.168.20.110.0 > 192.168.20.92.8300: UDP, length 44
	0x0000:  e8bd d101 77ec 8283 c0a8 146e 0800 4500  ....w......n..E.
	0x0010:  0048 d431 0000 3f11 fd58 c0a8 146e c0a8  .H.1..?..X...n..
	0x0020:  145c 0000 206c 0034 0000 0000 0000 7b00  .\...l.4......{.
	0x0030:  0002 7b00 0001 0000 0000 0100 0378 7b00  ..{..........x{.
	0x0040:  0001 c0a8 145d 6cdd ee00 0001 e8bd d101  .....]l.........
	0x0050:  72c8 001e 0000                           r.....
23:46:50.933239 e8:bd:d1:01:72:c8 > 82:83:c0:a8:14:66, ethertype IPv4 (0x0800), length 92: 192.168.20.93.38768 > 192.168.20.102.4789: VXLAN, flags [I] (0x08), vni 888
6c:dd:ee:00:00:01 > ff:ff:ff:ff:ff:ff, ethertype ARP (0x0806), length 42: Request who-has 123.0.0.2 tell 123.0.0.1, length 28
	0x0000:  8283 c0a8 1466 e8bd d101 72c8 0800 4500  .....f....r...E.
	0x0010:  004e b58e 4000 4011 dafc c0a8 145d c0a8  .N..@.@......]..
	0x0020:  1466 9770 12b5 003a 0000 0800 0000 0003  .f.p...:........
	0x0030:  7800 ffff ffff ffff 6cdd ee00 0001 0806  x.......l.......
	0x0040:  0001 0800 0604 0001 6cdd ee00 0001 7b00  ........l.....{.
	0x0050:  0001 0000 0000 0000 7b00 0002            ........{...
23:46:50.933823 82:83:c0:a8:14:6e > e8:bd:d1:01:77:ec, ethertype IPv4 (0x0800), length 148: 192.168.20.110.46639 > 192.168.20.92.4789: VXLAN, flags [I] (0x08), vni 888
6c:dd:ee:00:00:01 > 6c:dd:ee:00:00:02, ethertype IPv4 (0x0800), length 98: 123.0.0.1 > 123.0.0.2: ICMP echo reply, id 23422, seq 1, length 64
	0x0000:  e8bd d101 77ec 8283 c0a8 146e 0800 4500  ....w......n..E.
	0x0010:  0086 a47f 4000 3f11 eccc c0a8 146e c0a8  ....@.?......n..
	0x0020:  145c b62f 12b5 0072 0000 0800 0000 0003  .\./...r........
	0x0030:  7800 6cdd ee00 0002 6cdd ee00 0001 0800  x.l.....l.......
	0x0040:  4500 0054 cbac 0000 4001 b8f9 7b00 0001  E..T....@...{...
	0x0050:  7b00 0002 0000 b01f 5b7e 0001 eaf6 ff5f  {.......[~....._
	0x0060:  0000 0000 3d37 0e00 0000 0000 1011 1213  ....=7..........
	0x0070:  1415 1617 1819 1a1b 1c1d 1e1f 2021 2223  .............!"#
	0x0080:  2425 2627 2829 2a2b 2c2d 2e2f 3031 3233  $%&'()*+,-./0123
	0x0090:  3435 3637                                4567
```
Closes #66 