### PR TITLE
Doc fix

### DIFF
--- a/docs/design/zeta_system_design.md
+++ b/docs/design/zeta_system_design.md
@@ -1859,9 +1859,7 @@ External API definitions are based on phase I use cases and related system param
             "mac_tenant": "11:22:33:44:55:66",
             "inf_zgc": "eth2",
             "mac_zgc": "11:22:33:44:55:67",
-            "zgc_id": "f81d4fae-7dec-11d0-a765-00a0c91e6bf6",
-            "id_control": "user_name_of_node",
-            "pwd_control": "password_of_id_control"
+            "zgc_id": "f81d4fae-7dec-11d0-a765-00a0c91e6bf6"
         }
     Response:
         data:
@@ -1874,9 +1872,7 @@ External API definitions are based on phase I use cases and related system param
             "mac_tenant": "11:22:33:44:55:66",
             "inf_zgc": "eth2",
             "mac_zgc": "11:22:33:44:55:67",
-            "zgc_id": "f81d4fae-7dec-11d0-a765-00a0c91e6bf6",
-            "id_control": "user_name_of_node",
-            "pwd_control": "password_of_id_control"
+            "zgc_id": "f81d4fae-7dec-11d0-a765-00a0c91e6bf6"
         }
     ```
 

--- a/docs/design/zeta_system_design.md
+++ b/docs/design/zeta_system_design.md
@@ -1562,7 +1562,7 @@ External API definitions are based on phase I use cases and related system param
     Response:
         data:
         {
-            "id": "f81d4fae-7dec-11d0-a765-00a0c91e6bf6",
+            "zgc_id": "f81d4fae-7dec-11d0-a765-00a0c91e6bf6",
             "name": "ZGC_test",
             "description": "ZGC 1",
             "ip_start": "192.168.0.1",
@@ -1787,6 +1787,7 @@ External API definitions are based on phase I use cases and related system param
     Response:
         data:
         {
+            "id": 1,
             "vpc_id": "3dda2801-d675-4688-a63f-dcda8d327f50",
             "vni": "12345",
             "zgc_id": "f81d4fae-7dec-11d0-a765-00a0c91e6bf6",
@@ -1806,7 +1807,8 @@ External API definitions are based on phase I use cases and related system param
                 "mac": "37.02.ff.cc.65.89"
               }
             ],
-            "port_ibo": "8300"
+            "port_ibo": "8300",
+            "ports": []
         }
     ```
 
@@ -1857,7 +1859,9 @@ External API definitions are based on phase I use cases and related system param
             "mac_tenant": "11:22:33:44:55:66",
             "inf_zgc": "eth2",
             "mac_zgc": "11:22:33:44:55:67",
-            "zgc_id": "f81d4fae-7dec-11d0-a765-00a0c91e6bf6"
+            "zgc_id": "f81d4fae-7dec-11d0-a765-00a0c91e6bf6",
+            "id_control": "user_name_of_node",
+            "pwd_control": "password_of_id_control"
         }
     Response:
         data:
@@ -1870,7 +1874,9 @@ External API definitions are based on phase I use cases and related system param
             "mac_tenant": "11:22:33:44:55:66",
             "inf_zgc": "eth2",
             "mac_zgc": "11:22:33:44:55:67",
-            "zgc_id": "f81d4fae-7dec-11d0-a765-00a0c91e6bf6"
+            "zgc_id": "f81d4fae-7dec-11d0-a765-00a0c91e6bf6",
+            "id_control": "user_name_of_node",
+            "pwd_control": "password_of_id_control"
         }
     ```
 

--- a/docs/design/zeta_system_design.md
+++ b/docs/design/zeta_system_design.md
@@ -1979,8 +1979,7 @@ multiple IP addresses per port.
             "mac_port": "cc:dd:ee:ff:11:22",
             "ip_node": "192.168.10.27",
             "mac_node": "ee:dd:ee:ff:22:11",
-            "zgc_id": "f81d4fae-7dec-11d0-a765-00a0c91e6bf6",
-            "status": "pending"
+            "zgc_id": "f81d4fae-7dec-11d0-a765-00a0c91e6bf6"
           },
           {
             "port_id": "99976feae-7dec-11d0-a765-00a0c9341111",
@@ -1999,8 +1998,7 @@ multiple IP addresses per port.
             "mac_port": "6c:dd:ee:ff:11:32",
             "ip_node": "192.168.10.33",
             "mac_node": "ee:dd:ee:ff:33:11",
-            "zgc_id": "f81d4fae-7dec-11d0-a765-00a0c91e6bf6",
-            "status": "pending"
+            "zgc_id": "f81d4fae-7dec-11d0-a765-00a0c91e6bf6"
           }
         ]
     ```


### PR DESCRIPTION
This PR is created to reflect the changes in several zeta APIs responses.

Evidence of APIs' response changes, got from running the pseudo controller:
- For `/zgcs POST`:
```
ZGC_data:
{'name': 'ZGC_test106', 'description': 'ZGC_test106', 'ip_start': '192.168.20.100', 'ip_end': '192.168.20.115', 'port_ibo': '8300', 'overlay_type': 'vxlan'}
zgc creation response:
{
  "description": "ZGC_test106",
  "ip_end": "192.168.20.115",
  "ip_start": "192.168.20.100",
  "name": "ZGC_test106",
  "overlay_type": "vxlan",
  "port_ibo": "8300",
  "zgc_id": "7d5937dc-f7ec-40f8-8551-65d4386e798c"
}
```
- For `/vpcs POST`:
```
VPC_data:
{'vpc_id': '3dda2801-d675-4688-a63f-dcda8d327f61', 'vni': '888'}
Response for adding VPC: {
  "gws": [
....................
  ],
  "id": 1,
  "port_ibo": "8300",
  "ports": [],
  "vni": 888,
  "vpc_id": "3dda2801-d675-4688-a63f-dcda8d327f61",
  "zgc_id": "7d5937dc-f7ec-40f8-8551-65d4386e798c"
}
```
- For `/nodes POST`:
```
node_data:
{'zgc_id': '7d5937dc-f7ec-40f8-8551-65d4386e798c', 'description': 'znode190', 'name': 'znode190', 'ip_control': 'ip_of_node', 'id_control': 'user_name_of_node', 'pwd_control': 'password_of_user_name', 'inf_tenant': 'ens4', 'mac_tenant': '52:54:00:c7:b7:xx', 'inf_zgc': 'ens3', 'mac_zgc': '52:54:00:07:c0:xx'}
Response for adding node: {
  "description": "znode190",
  "id_control": "user_name_of_node",
  "inf_tenant": "ens4",
  "inf_zgc": "ens3",
  "ip_control": "ip_of_node",
  "mac_tenant": "52:54:00:c7:b7:xx",
  "mac_zgc": "52:54:00:07:c0:xx",
  "name": "znode190",
  "node_id": "ef0e8b0d-c6aa-4a7c-8f37-c615c5a32094",
  "pwd_control": "password_of_user_name",
  "zgc_id": "7d5937dc-f7ec-40f8-8551-65d4386e798c"
}
```
- For `/ports POST`
```
Response data:
[{
		"ip_node": "192.168.20.93",
		"ips_port": [{
			"ip": "123.0.0.1",
			"vip": ""
		}],
		"mac_node": "e8:bd:d1:01:72:xx",
		"mac_port": "6c:dd:ee:0:0:xx",
		"port_id": "0000001ae-7dec-11d0-a765-00a0c9341120",
		"vpc_id": "3dda2801-d675-4688-a63f-dcda8d327f61"
	}, {
		"ip_node": "192.168.20.92",
		"ips_port": [{
			"ip": "123.0.0.2",
			"vip": ""
		}],
		"mac_node": "e8:bd:d1:01:77:xx",
		"mac_port": "6c:dd:ee:0:0:xx",
		"port_id": "0000002ae-7dec-11d0-a765-00a0c9341120",
		"vpc_id": "3dda2801-d675-4688-a63f-dcda8d327f61"
	}]
```